### PR TITLE
Bug 1440492 - Add pip check to the Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - pip install -r requirements.txt
   - pip install .
 script:
+  - pip check
   - python test/runtests.py --use-local
 notifications:
   irc: "irc.mozilla.org#pulse"


### PR DESCRIPTION
Since it ensures the version constraints of sub-dependencies are met:
https://pip.pypa.io/en/latest/reference/pip_check/