### PR TITLE
Rename "User" to "Pulse Guardian User" in the UI.

### DIFF
--- a/pulseguardian/templates/all_users.html
+++ b/pulseguardian/templates/all_users.html
@@ -2,13 +2,13 @@
 
 {% block body %}
 <div class="col-md-12">
-  <h3>All Users</h3>
+  <h3>All Pulse Guardian Users</h3>
 
   <ul class="list-group users">
     <table id="users" width="100%">
       <thead>
         <tr>
-          <th>User</th>
+          <th>Pulse Guardian User</th>
           <th>Admin</th>
         </tr>
       </thead>

--- a/pulseguardian/templates/menu.html
+++ b/pulseguardian/templates/menu.html
@@ -7,7 +7,7 @@
         <h4><a class="menuitem" href="/queues">Queues</a></h4>
 
         {% if g.user.admin %}
-        <h4><a class="menuitem" href="/all_users">All Users</a></h4>
+        <h4><a class="menuitem" href="/all_users">All Pulse Guardian Users</a></h4>
         {% endif %}
     {% endif %}
   </div>

--- a/pulseguardian/templates/profile.html
+++ b/pulseguardian/templates/profile.html
@@ -46,7 +46,7 @@
                  class="form-control"/>
 
           <br/>
-          <strong>Owners:</strong>(comma separated)
+          <strong>Owners:</strong> (comma separated)
           <input name="owners-list" type="text" value="{{ pulse_user.owners|join(',', attribute='email')|default(cur_user.email, true) }}"
                  class="form-control"/>
 

--- a/pulseguardian/templates/queues_listing.html
+++ b/pulseguardian/templates/queues_listing.html
@@ -72,7 +72,7 @@
 {% endmacro %}
 
 {% if users|length > 1 %}
-  <h2>Users</h2>
+  <h2>Pulse Guardian Users</h2>
 
   {% for user in users %}
     <h3 class="text-primary" data-email="{{user.email}}">

--- a/pulseguardian/templates/register.html
+++ b/pulseguardian/templates/register.html
@@ -39,7 +39,7 @@
              class="form-control"/>
     </div>
     <div class="form-group">
-      <strong>Owners:</strong>(comma separated)
+      <strong>Owners:</strong> (comma separated)
       <input name="owners-list" type="text" value="{{ cur_user.email }}"
              class="form-control"/>
     </div>


### PR DESCRIPTION
This is part one of clarifying the difference between the
users who log into Pulse Guardian and the accounts created on
Pulse/RabbitMQ.  In this case, we're going to leave the underlying
data structures with the same name, since after the change from
"Pulse User" to "RabbitMQ Account" the term "User" will be a lot
less ambiguous.