### PR TITLE
Rename "Pulse user" to "RabbitMQ account" in the UI

### DIFF
--- a/pulseguardian/templates/all_pulse_users.html
+++ b/pulseguardian/templates/all_pulse_users.html
@@ -2,13 +2,13 @@
 
 {% block body %}
 <div class="col-md-12">
-  <h3>All Pulse Users</h3>
+  <h3>All RabbitMQ Accounts</h3>
 
   <ul class="list-group pulse-users" data-csrf-token="{{ csrf_token() }}">
     <table id="pulse_users" width="100%">
       <thead>
         <tr>
-          <th>Pulse User</th>
+          <th>RabbitMQ Account</th>
           <th>Owners</th>
           {% if g.user.admin %}
           <th>Actions</th>

--- a/pulseguardian/templates/dialogs.html
+++ b/pulseguardian/templates/dialogs.html
@@ -16,4 +16,4 @@
 {% endmacro %}
 
 {{ confirm_dialog('queue', 'queue') }}
-{{ confirm_dialog('Pulse user', 'pulse-user') }}
+{{ confirm_dialog('RabbitMQ account', 'pulse-user') }}

--- a/pulseguardian/templates/menu.html
+++ b/pulseguardian/templates/menu.html
@@ -2,8 +2,8 @@
   <div class="container">
     <h4><a class="menuitem" href="/whats_pulse">What's Pulse?</a></h4>
     {% if session.get('userinfo') %}
-        <h4><a class="menuitem" href="/profile">My Pulse Users</a></h4>
-        <h4><a class="menuitem" href="/all_pulse_users">All Pulse Users</a></h4>
+        <h4><a class="menuitem" href="/profile">My RabbitMQ Accounts</a></h4>
+        <h4><a class="menuitem" href="/all_pulse_users">All RabbitMQ Accounts</a></h4>
         <h4><a class="menuitem" href="/queues">Queues</a></h4>
 
         {% if g.user.admin %}

--- a/pulseguardian/templates/profile.html
+++ b/pulseguardian/templates/profile.html
@@ -10,7 +10,7 @@
     <div class="alert alert-danger">{{error}}</div>
   {% endif %}
 
-  <h3>Pulse Users
+  <h3>RabbitMQ Accounts
     <span class="pull-right">
       <a href="register"><span class="glyphicon glyphicon-plus add"></span></a>
     </span>

--- a/pulseguardian/templates/queues_listing.html
+++ b/pulseguardian/templates/queues_listing.html
@@ -65,7 +65,7 @@
     {% endfor %}
   {% else %}
     <p>
-      No Pulse users!
+      No RabbitMQ accounts!
     </p>
   {% endif %}
 </div>

--- a/pulseguardian/templates/register.html
+++ b/pulseguardian/templates/register.html
@@ -6,7 +6,7 @@
     <div class="alert alert-danger">{{error}}</div>
   {% endif %}
 
-  <h2>Register a Pulse user</h2>
+  <h2>Register a RabbitMQ account</h2>
 
   {% if signup_errors %}
     <div class="alert alert-danger">

--- a/pulseguardian/web.py
+++ b/pulseguardian/web.py
@@ -378,7 +378,7 @@ def delete_pulse_user(pulse_username):
             mozdef.log(
                 mozdef.ERROR,
                 mozdef.OTHER,
-                'Error deleting Pulse user',
+                'Error deleting RabbitMQ account',
                 details=details,
             )
             return jsonify(ok=False)
@@ -386,7 +386,7 @@ def delete_pulse_user(pulse_username):
         mozdef.log(
             mozdef.NOTICE,
             mozdef.OTHER,
-            'Pulse user deleted',
+            'RabbitMQ account deleted',
             details=details,
         )
         db_session.delete(pulse_user)
@@ -469,7 +469,7 @@ def update_info():
             PulseUser.username == pulse_username).one()
     except sqlalchemy.orm.exc.NoResultFound:
         return profile(
-            messages=["Pulse user {} not found.".format(pulse_username)])
+            messages=["RabbitMQ account {} not found.".format(pulse_username)])
 
     if g.user not in pulse_user.owners:
         return profile(
@@ -569,7 +569,7 @@ def register_handler():
 
     if (in_rabbitmq or
             PulseUser.query.filter(PulseUser.username == username).first()):
-        errors.append("A user with the same username already exists.")
+        errors.append("An account with the same username already exists.")
 
     if errors:
         return render_template('register.html', email=email,


### PR DESCRIPTION
"Pulse user" is an ambiguous descriptor, so we're renaming it
to the more factual "RabbitMQ account".  This change only
affects displayed text.

This is another part of fixing #38.