### PR TITLE
Add more details to logging

### DIFF
--- a/pulseguardian/mozdef.py
+++ b/pulseguardian/mozdef.py
@@ -32,5 +32,5 @@ STARTUP = 'Startup'
 
 
 def log(sev, cat, summary, details=None, tags=None):
-    print '[{}] {}'.format(cat, summary)
+    print '[{}] {} {} {}'.format(cat, summary, json.dumps(details), json.dumps(tags))
 


### PR DESCRIPTION
I haven't checked every instance of logging details to make sure that it isn't leaking anything, but I assume the previous owner would have been careful with that they're asking to explicitly log. I want to figure out why these weren't logged before though.