### PR TITLE
Bug 1648498 - use config.rabbit_vhost everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 language: python
 services:
   - rabbitmq
+env:
+  - FLASK_SECRET_KEY=H5uMeOWaXO6iuEQxn9DR8GWutA9oZxWQ DATABASE_URL=sqlite:////home/travis/db
 python:
   - "3.6"
 before_install:
@@ -13,9 +15,6 @@ install:
 script:
   - pip check
   - python test/runtests.py --use-local
-notifications:
-  irc: "irc.mozilla.org#pulse"
-  on_success: change
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 services:
   - rabbitmq
 env:
-  - FLASK_SECRET_KEY=H5uMeOWaXO6iuEQxn9DR8GWutA9oZxWQ DATABASE_URL=sqlite:////home/travis/db
+  - DATABASE_URL=sqlite:////home/travis/db
 python:
   - "3.6"
 before_install:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ your system.
 To create a Pulse Docker image, run this from within the root PulseGuardian
 source directory:
 
-    docker build -t="pulse:testing" docker/pulse
+    docker build -t="pulse:testing" test
 
 When that finishes building, you can run a RabbitMQ instance in a Docker
 container with

--- a/gen_secret_key.py
+++ b/gen_secret_key.py
@@ -6,4 +6,4 @@ import base64
 import os
 
 key = os.urandom(24)
-print(base64.b64encode(key))
+print(base64.b64encode(key).decode('ascii'))

--- a/pulseguardian/guardian.py
+++ b/pulseguardian/guardian.py
@@ -408,8 +408,8 @@ Error:
             )
 
             try:
-                queues = pulse_management.queues()
-                bindings = pulse_management.bindings()
+                queues = pulse_management.queues(vhost=config.rabbit_vhost)
+                bindings = pulse_management.bindings(vhost=config.rabbit_vhost)
 
                 mozdef.log(
                     mozdef.DEBUG,

--- a/pulseguardian/management.py
+++ b/pulseguardian/management.py
@@ -77,9 +77,13 @@ def delete_all_queues():
         delete_queue(queue_data['vhost'], queue_data['name'])
 
 
-def bindings():
+def bindings(vhost):
     """All bindings for all queues"""
-    bindings = _api_request('bindings')
+    if vhost:
+        vhost = quote(vhost, '')
+        bindings = _api_request('bindings/{0}'.format(vhost))
+    else:
+        bindings = _api_request('bindings')
     return [b for b in bindings if b["source"]]
 
 

--- a/pulseguardian/web.py
+++ b/pulseguardian/web.py
@@ -335,7 +335,7 @@ def delete_queue(queue_name):
         }
 
         try:
-            pulse_management.delete_queue(vhost='/', queue=queue.name)
+            pulse_management.delete_queue(vhost=config.rabbit_vhost, queue=queue.name)
         except pulse_management.PulseManagementException as e:
             details['message'] = str(e)
             mozdef.log(
@@ -454,7 +454,7 @@ def bindings_listing(queue_name):
     queue = Queue.query.get(queue_name)
     bindings = []
     if queue:
-        bindings = pulse_management.queue_bindings(vhost='/', queue=queue.name)
+        bindings = pulse_management.queue_bindings(vhost=config.rabbit_vhost, queue=queue.name)
     return jsonify({"queue_name": queue_name, "bindings": bindings})
 
 

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -241,8 +241,8 @@ class GuardianTest(unittest.TestCase):
             attempts += 1
             if attempts > 1:
                 time.sleep(self.QUEUE_RECORD_CHECK_PERIOD)
-            self.guardian.monitor_queues(pulse_management.queues(),
-                                         pulse_management.bindings())
+            self.guardian.monitor_queues(pulse_management.queues(vhost='/'),
+                                         pulse_management.bindings(vhost='/'))
             if Queue.query.filter(Queue.name == consumer.queue_name).first():
                 break
 
@@ -254,8 +254,8 @@ class GuardianTest(unittest.TestCase):
             attempts += 1
             if attempts > 1:
                 time.sleep(self.QUEUE_RECORD_CHECK_PERIOD)
-            self.guardian.monitor_queues(pulse_management.queues(),
-                                         pulse_management.bindings())
+            self.guardian.monitor_queues(pulse_management.queues(vhost='/'),
+                                         pulse_management.bindings(vhost='/'))
             if Binding.query.filter(
                                     Binding.queue_name == queue_name,
                                     Binding.exchange == exchange_name,
@@ -270,8 +270,8 @@ class GuardianTest(unittest.TestCase):
             attempts += 1
             if attempts > 1:
                 time.sleep(self.QUEUE_RECORD_CHECK_PERIOD)
-            self.guardian.clear_deleted_queues(pulse_management.queues(),
-                                               pulse_management.bindings())
+            self.guardian.clear_deleted_queues(pulse_management.queues(vhost='/'),
+                                               pulse_management.bindings(vhost='/'))
             if not Binding.query.filter(
                                         Binding.queue_name == queue_name,
                                         Binding.exchange == exchange_name,
@@ -361,8 +361,8 @@ class GuardianTest(unittest.TestCase):
         self.assertGreater(len(queues_to_warn), 0)
 
         # Monitor the queues; this should detect queues that should be warned.
-        self.guardian.monitor_queues(pulse_management.queues(),
-                                     pulse_management.bindings())
+        self.guardian.monitor_queues(pulse_management.queues(vhost='/'),
+                                     pulse_management.bindings(vhost='/'))
 
         # Refresh the user's queues state.
         db_session.refresh(self.rabbitmq_account)
@@ -417,8 +417,8 @@ class GuardianTest(unittest.TestCase):
         self.guardian.on_delete = on_delete
 
         # Monitor the queues; this should delete overgrown queues
-        self.guardian.monitor_queues(pulse_management.queues(),
-                                     pulse_management.bindings())
+        self.guardian.monitor_queues(pulse_management.queues(vhost='/'),
+                                     pulse_management.bindings(vhost='/'))
 
         # Test that the queues that had to be deleted were deleted...
         self.assertTrue(not any(q in queues_to_delete for q
@@ -476,8 +476,8 @@ class GuardianTest(unittest.TestCase):
         # that has grown too large.
         # In this case, it should run the check and decide to not delete
         # any queues.
-        self.guardian.monitor_queues(pulse_management.queues(),
-                                     pulse_management.bindings())
+        self.guardian.monitor_queues(pulse_management.queues(vhost='/'),
+                                     pulse_management.bindings(vhost='/'))
 
         # Test that none of the queues were deleted...
         self.assertTrue(all(q in queues_to_delete for q

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -17,6 +17,8 @@ from kombu import Exchange
 from mozillapulse import consumers, publishers
 from mozillapulse.messages.test import TestMessage
 
+os.environ['FLASK_SECRET_KEY'] = base64.b64encode(os.urandom(24)).decode('ascii')
+
 from pulseguardian import config
 
 # Change the DB for the tests and set fake_account *before* the model is initialized.
@@ -33,8 +35,6 @@ from pulseguardian.model.binding import Binding
 from pulseguardian.model.pulse_user import RabbitMQAccount
 from pulseguardian.model.queue import Queue
 from pulseguardian.model.user import User
-
-os.environ['FLASK_SECRET_KEY'] = base64.b64encode(os.urandom(24)).decode('ascii')
 
 web.app.config['TESTING'] = True
 

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -17,8 +17,11 @@ from kombu import Exchange
 from mozillapulse import consumers, publishers
 from mozillapulse.messages.test import TestMessage
 
-# Change the DB for the tests before the model is initialized.
 from pulseguardian import config
+
+# Change the DB for the tests and set fake_account *before* the model is initialized.
+config.database_url = 'sqlite:///pulseguardian_test.db'
+config.fake_account = 'guardtest@guardtest.com'
 
 from docker_setup import (check_rabbitmq, create_image,
                           setup_container, teardown_container)
@@ -32,9 +35,6 @@ from pulseguardian.model.queue import Queue
 from pulseguardian.model.user import User
 
 os.environ['FLASK_SECRET_KEY'] = base64.b64encode(os.urandom(24)).decode('ascii')
-
-config.database_url = 'sqlite:///pulseguardian_test.db'
-config.fake_account = 'guardtest@guardtest.com'
 
 web.app.config['TESTING'] = True
 


### PR DESCRIPTION
pulseguardian in general just refers to queues by name, without qualifying them with a vhost.  So in keeping with the definition of "pulse" as a single rabbitmq vhost, let's be comprehensive in instructing pulseguardian to only look at the configured vhost.