### PR TITLE
Replace ancient pinned Mozilla version of Flask-pyoidc lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ chardet==3.0.4
 click==7.1.2
 cryptography==3.2.1
 Flask==1.1.2
-https://github.com/mozilla-iam/Flask-pyoidc/archive/v1.0.0.tar.gz
+Flask-pyoidc==3.7.0
 Flask-SSLify==0.1.5
 funcsigs==1.0.2
 future==0.18.2


### PR DESCRIPTION
This is an offshoot to PR#337.

AFAICT there's no good reason to stay on the Mozilla pinned version of Flask-pyoidc, especially in the face of sec vulns.