### PR TITLE
fix: `/queues` timeout and worker crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ queues. More information on [the wiki][].
 
 ## Pre-requisites
 
-* RabbitMQ (tested on 3.5.7)
+* RabbitMQ (tested on 4.2.4)
 * Python 3.13+
 * pip or [uv](https://docs.astral.sh/uv/) (to install dependencies)
 * PostgreSQL (for production; testing environments can use sqlite)

--- a/pulseguardian/guardian.py
+++ b/pulseguardian/guardian.py
@@ -184,7 +184,9 @@ class PulseGuardian(object):
                     # RabbitMQAccount needs at least one owner as well, but
                     # since we have no way of knowing who really owns it, find
                     # the first admin, and set it to that.
-                    user = User.get_by(admin=True)
+                    user = db_session.execute(
+                        select(User).where(User.admin == True).limit(1)
+                    ).scalar_one_or_none()
                     owner = RabbitMQAccount.new_user(owner_name, owners=user)
 
             mozdef.log(

--- a/pulseguardian/web.py
+++ b/pulseguardian/web.py
@@ -53,7 +53,7 @@ from flask import (
 )
 from flask_secure_headers.core import Secure_Headers
 from sqlalchemy import select
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, subqueryload
 from werkzeug.exceptions import NotFound
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -354,19 +354,36 @@ def all_pulse_users():
     )
 
 
-@app.route("/queues")
-@sh.wrapper()
-@oidc.oidc_auth
-def queues():
+def _load_queues_data():
+    """Load users with eagerly-loaded rabbitmq_accounts, queues, and bindings."""
     if g.user.admin:
-        users = User.get_all()
+        users = list(
+            db_session.execute(
+                select(User).options(
+                    subqueryload(User.rabbitmq_accounts)
+                    .subqueryload(RabbitMQAccount.queues)
+                    .subqueryload(Queue.bindings)
+                )
+            ).scalars().unique()
+        )
         no_owner_queues = list(
-            db_session.execute(select(Queue).where(Queue.owner == None)).scalars()
+            db_session.execute(
+                select(Queue)
+                .where(Queue.owner == None)
+                .options(subqueryload(Queue.bindings))
+            ).scalars()
         )
     else:
         users = [current_user(session)]
         no_owner_queues = []
+    return users, no_owner_queues
 
+
+@app.route("/queues")
+@sh.wrapper()
+@oidc.oidc_auth
+def queues():
+    users, no_owner_queues = _load_queues_data()
     return render_template("queues.html", users=users, no_owner_queues=no_owner_queues)
 
 
@@ -374,15 +391,7 @@ def queues():
 @sh.wrapper()
 @oidc.oidc_auth
 def queues_listing():
-    if g.user.admin:
-        users = User.get_all()
-        no_owner_queues = list(
-            db_session.execute(select(Queue).where(Queue.owner == None)).scalars()
-        )
-    else:
-        users = [current_user(session)]
-        no_owner_queues = []
-
+    users, no_owner_queues = _load_queues_data()
     return render_template(
         "queues_listing.html", users=users, no_owner_queues=no_owner_queues
     )

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -721,6 +721,91 @@ class WebTest(unittest.TestCase):
             config.reserved_users_regex = None
             config.reserved_users_message = None
 
+class QueryPerformanceTest(unittest.TestCase):
+    """Tests for database query performance (no RabbitMQ required)."""
+
+    def setUp(self):
+        """Initialize DB without calling RabbitMQ management API."""
+        from pulseguardian.model.base import init_db
+
+        init_db()
+        for tbl in [Binding, Queue, RabbitMQAccount, User]:
+            for obj in tbl.get_all():
+                db_session.delete(obj)
+        db_session.commit()
+
+    def test_queues_page_eagerly_loads_relationships(self):
+        """The /queues endpoint must not lazy-load relationships during
+        template rendering.  With lazy loading, each user/account/queue
+        triggers separate SQL queries (N+1), causing gunicorn worker
+        timeouts on production data sets.
+
+        We verify by counting SQL statements: with eager loading the
+        count stays bounded regardless of how many users/accounts/queues
+        exist.
+        """
+        from sqlalchemy import event
+        from pulseguardian.model.base import engine
+
+        # Create an admin user (the one fake_account resolves to)
+        admin_user = User.new_user(email=CONSUMER_EMAIL, admin=True)
+
+        # Create 5 users, each with a rabbitmq account, a queue, and a binding
+        for i in range(5):
+            user = User.new_user(email="user{}@test.com".format(i))
+            acct = RabbitMQAccount.new_user(
+                "user{}".format(i), owners=[user], create_rabbitmq_user=False
+            )
+
+            queue = Queue(name="queue/user{}/test".format(i), owner=acct, size=0)
+            db_session.add(queue)
+            db_session.commit()
+
+            binding = Binding(
+                exchange="exchange/user{}".format(i),
+                routing_key="test.#",
+                queue_name=queue.name,
+            )
+            db_session.add(binding)
+            db_session.commit()
+
+        # Track query count
+        query_count = [0]
+
+        def count_queries(conn, cursor, statement, parameters, context, executemany):
+            query_count[0] += 1
+
+        event.listen(engine, "before_cursor_execute", count_queries)
+        try:
+            with web.app.test_client() as c:
+                c.application.template_folder = "{}/pulseguardian/templates".format(
+                    os.getcwd()
+                )
+                with c.session_transaction() as sess:
+                    sess["email"] = CONSUMER_EMAIL
+                    sess["fake_account"] = True
+                    sess["logged_in"] = True
+
+                # Expire all cached state so the request must query the DB
+                db_session.expire_all()
+
+                response = c.get("/queues")
+                self.assertEqual(response.status_code, 200)
+        finally:
+            event.remove(engine, "before_cursor_execute", count_queries)
+
+        # With 5 users, lazy loading would issue at least:
+        #   1 (users) + 5 (rabbitmq_accounts per user) + 5 (queues per acct)
+        #   + 5 (bindings per queue) = 16+ queries
+        # Eager loading should use a small bounded number of queries
+        # (around 4-5: users, accounts, queues, bindings, plus unowned queues)
+        self.assertLessEqual(
+            query_count[0],
+            10,
+            "Too many queries ({}): relationships are likely lazy-loaded "
+            "(N+1 problem). Use eager loading.".format(query_count[0]),
+        )
+
 
 class AuthTest(unittest.TestCase):
     """Tests for OIDC/authlib authentication flow."""


### PR DESCRIPTION
Fixes #495.

Updates with the changes needed from the heroku git repo to get the recent deployment to build properly.