### PR TITLE
fix: keep CSRF token valid across multiple deletes (#251)

### DIFF
--- a/pulseguardian/static/js/deletable.js
+++ b/pulseguardian/static/js/deletable.js
@@ -7,6 +7,11 @@
 // confirmation dialog) which should be organized better.  See also
 // dialogs.html.
 
+function errorMessage(message) {
+    console.error(message);
+    alert(message);
+}
+
 function deletableObjectHandler(collectionClass, objectType) {
     $('.' + objectType + 's .delete').click(function() {
         var objectInstance = $(this).closest('.' + objectType);

--- a/pulseguardian/web.py
+++ b/pulseguardian/web.py
@@ -250,7 +250,7 @@ def _csrf_protect():
         else:
             return
 
-        session_csrf_token = session.pop("_csrf_token", None)
+        session_csrf_token = session.get("_csrf_token")
 
         if not session_csrf_token or session_csrf_token != page_csrf_token:
             abort(400)
@@ -289,6 +289,7 @@ def callback():
     token = authentication.oauth.auth0.authorize_access_token()
     session["userinfo"] = token["userinfo"]
     session["id_token"] = token["id_token"]
+    session.pop("_csrf_token", None)
 
     g.user = _load_user_from_email(session["userinfo"]["email"])
 


### PR DESCRIPTION
Use session.get instead of session.pop so the token stays valid for the session, matching Django/Rails/Flask-WTF defaults. Existing defenses (HttpOnly + SameSite=Lax cookies, X-CSRF-Token header on DELETE, no CORS) cover the threat model.

Also rotate the token in the OAuth callback on login, and define the missing errorMessage helper so DELETE failures surface to the user.

Fixes #251.